### PR TITLE
Fix placement of error not to obscure remove button

### DIFF
--- a/src/views/index.ejs
+++ b/src/views/index.ejs
@@ -35,8 +35,11 @@
             display: block;
             line-height: 100px;
         }
-        .dz-image{
+        .dz-image {
             border-radius: 0 !important;
+        }
+        .dz-error-message {
+            top: 155px !important;
         }
         .btnCopy {
             font-size: 14px;


### PR DESCRIPTION
Fix placement of the error box so it does not obscure the remove button.

https://github.com/waifuvault/waifuPics/issues/3

Minor style update all thats required.

![Screen Shot 2024-10-04 at 7 42 38 PM](https://github.com/user-attachments/assets/80a078f6-2efa-44d0-8f31-2528c40522e2)
